### PR TITLE
Adds Pashto language

### DIFF
--- a/index.json
+++ b/index.json
@@ -33250,6 +33250,15 @@
     "iso6393": "pur"
   },
   {
+    "name": "Pashto",
+    "type": "living",
+    "scope": "macrolanguage",
+    "iso6393": "pus",
+    "iso6392B": "pus",
+    "iso6392T": "pus",
+    "iso6391": "ps"
+  },
+  {
     "name": "Pushto",
     "type": "living",
     "scope": "macrolanguage",


### PR DESCRIPTION
According to the list of [ISO-639 codes](https://iso639-3.sil.org/code_tables/639/data?title=&field_iso639_cd_st_mmbrshp_639_1_tid=All&name_3=Pashto&field_iso639_element_scope_tid=All&field_iso639_language_type_tid=All&items_per_page=200), the Pashto language has several acceptable spelling options: `Pashto` and `Pushto`. Current version contains only `Pushtu`.